### PR TITLE
Optionally shutdown the service (and server) if no activity is detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,19 @@ That service in turn *binds to* another, and therefore makes *systemd* schedule 
 BindsTo=avorion-server.service
 After=avorion-server.service
 
+# stop the game server if this service is stopped
+PropagatesStopTo=avorion-server.service
+
 [Service]
 Type=notify
 ExecStart=/opt/sbin/systemd-transparent-udp-forwarderd \
   172.16.28.240:27000 \
   172.16.28.240:27003 \
   172.16.28.240:27020 \
-  172.16.28.240:27021
+  172.16.28.240:27021 \
+  1800
+# ^^^^ this parameter is optional and allows the service to shut down after
+#      1800 seconds of inactivity
 ```
 
 Avorion's *service file* looks like this (excerpt). The corresponding *container address* is the important part:

--- a/udp-proxy.c
+++ b/udp-proxy.c
@@ -81,6 +81,8 @@ static int __attribute__((nonnull)) safe_atou16(const char *s, uint16_t *ret) {
 /* These counters are reset in display_stats(). */
 static size_t received_counter = 0, sent_counter = 0;
 static bool overflow = false;
+static uint16_t activity_timeout = 0;
+static sd_event_source *activity_timeout_source = NULL;
 
 /* udp_forward sends the datagram from |*msg| to address |*dstaddr|.
  * Its source will be the original source found in |msg|.
@@ -165,6 +167,10 @@ static void *payload_buffer;
  * Negative return values indicate an fatal error. A corresponding error message will be sent to
  * systemd's journal. */
 static int udp_receive(sd_event_source *es, int fd, uint32_t revents, void *userdata) {
+	if (activity_timeout > 0) {
+		(void) sd_event_source_set_time_relative(activity_timeout_source, (uint64_t)(activity_timeout) * 1000000); /* reschedules timeout */
+	}
+
 	if (unlikely(__builtin_add_overflow(received_counter, 1, &received_counter))) { /* Not thread-safe, but this is a single-threaded program. */
 		overflow = true;
 	}
@@ -343,6 +349,17 @@ static int display_stats(sd_event_source *es, uint64_t now, void *userdata) {
 	return 0;
 }
 
+/* activity_timeout_handler is a timer which exit the service if no activity is
+ * detected on the socket for some time.
+ *
+ * MT: This is not thread-safe, but this program is single-threaded.
+ *
+ * activity_timeout_handler is expected to be called by the event loop. */
+static int activity_timeout_handler(sd_event_source *es, uint64_t now, void *userdata) {
+	(void) sd_event_exit(sd_event_source_get_event(es), 0);
+	return 0;
+}
+
 /* main accepts any and all sockets handed over by PID 1, matches them with destinations from
  * |*argv[]|, and setups the event loop and its callbacks.
  *
@@ -352,9 +369,17 @@ static int display_stats(sd_event_source *es, uint64_t now, void *userdata) {
  * on STDERR, or sent to systemd's journal. */
 int main(int argc, char *argv[]) {
 	int n_systemd_sockets = sd_listen_fds(0);
-	if ((n_systemd_sockets + 1) != argc) {
+	if ((n_systemd_sockets + 2) < argc || (n_systemd_sockets + 1) > argc) {
 		(void) sd_journal_print(LOG_ERR, "Mismatch in received sockets %d != %d destinations.", n_systemd_sockets, (argc - 1));
 		return EXIT_FAILURE;
+	}
+
+	if ((n_systemd_sockets + 2) == argc) {
+		if (safe_atou16(argv[argc - 1], &activity_timeout) < 0) {
+			(void) sd_journal_print(LOG_CRIT, "Failed to parse activity delay before timeout: %s", argv[argc - 1]);
+			return 75;
+		}
+		(void) sd_journal_print(LOG_INFO, "Activity delay before timeout: %d", activity_timeout);
 	}
 
 	int exit_code = EXIT_SUCCESS;
@@ -460,6 +485,14 @@ int main(int argc, char *argv[]) {
 	}
 	(void) sd_event_source_set_enabled(timer_source, SD_EVENT_ON);
 
+	/* Set the timer for when there is no activity */
+	if (activity_timeout > 0) {
+		(void) sd_event_add_time_relative(event, &activity_timeout_source,
+			CLOCK_MONOTONIC, (uint64_t)(activity_timeout) * 1000000, 0,
+			activity_timeout_handler, NULL);
+		(void) sd_event_source_set_enabled(timer_source, SD_EVENT_ON);
+	}
+
 	/* Block on main event-loop call. */
 	(void) sd_journal_print(LOG_INFO, "Written by W. Mark Kubacki <wmark@hurrikane.de> https://github.com/wmark");
 	(void) sd_journal_print(LOG_INFO, "Done setting everything up. Serving.");
@@ -474,6 +507,11 @@ finish:
 	if (timer_source != NULL) {
 		(void) sd_event_source_set_enabled(timer_source, SD_EVENT_OFF);
 		timer_source = sd_event_source_unref(timer_source);
+	}
+
+	if (activity_timeout_source != NULL) {
+		(void) sd_event_source_set_enabled(activity_timeout_source, SD_EVENT_OFF);
+		activity_timeout_source = sd_event_source_unref(activity_timeout_source);
 	}
 
 	(void) sd_journal_print(LOG_DEBUG, "Freeing references to event-source and the event-loop.");

--- a/udp-proxy.c
+++ b/udp-proxy.c
@@ -369,6 +369,12 @@ static int activity_timeout_handler(sd_event_source *es, uint64_t now, void *use
  * on STDERR, or sent to systemd's journal. */
 int main(int argc, char *argv[]) {
 	int n_systemd_sockets = sd_listen_fds(0);
+
+	if (n_systemd_sockets == 0) {
+		(void) sd_journal_print(LOG_ERR, "No systemd sockets received");
+		return EXIT_FAILURE;
+	}
+
 	if ((n_systemd_sockets + 2) < argc || (n_systemd_sockets + 1) > argc) {
 		(void) sd_journal_print(LOG_ERR, "Mismatch in received sockets %d != %d destinations.", n_systemd_sockets, (argc - 1));
 		return EXIT_FAILURE;
@@ -377,7 +383,7 @@ int main(int argc, char *argv[]) {
 	if ((n_systemd_sockets + 2) == argc) {
 		if (safe_atou16(argv[argc - 1], &activity_timeout) < 0) {
 			(void) sd_journal_print(LOG_CRIT, "Failed to parse activity delay before timeout: %s", argv[argc - 1]);
-			return 75;
+			return EXIT_FAILURE;
 		}
 		(void) sd_journal_print(LOG_INFO, "Activity delay before timeout: %d", activity_timeout);
 	}


### PR DESCRIPTION
Hello,

I'm currently playing Palworld but the dedicated server does not currently have
an option to pause when no one is connected. This consume precious energy for
nothing when no one is connected.

I don't know much about C and systemd but I managed to update
systemd-transparent-udp-forwarderd to accept an "activity timeout" parameter at
the end of its arguments. When provided, if there is nothing on the network
during that amount of time (in seconds), then the service stops. I also added a
line in the proxy service to allow the stop to be propagated to the actual
server.

To test I made a simple UDP server and it worked fine. Unfortunately I couldn't
make systemd-transparent-udp-forwarderd work with Palworld, even without my
changes. I can see in the status message that some messages are being
transferred but the client fails to join with the generic "timeout" error. When
I look at the code I see nothing to handle the messages coming back from the
game server, could this be related? Maybe I need to add a iptables rule or
something?

Anyway... maybe I messed up something or Palworld don't work well with
systemd-transparent-udp-forwarderd. But the feature I made does work and might
be worth to keep. I'll let you be the judge of that.

Here are my unit files in case you can see something is wrong:

(The dedicated server and proxy are on the same remote machine, only the game
client itself is on my machine.)

`palworld.service`:

```
[Unit]
Description=Palworld Dedicated Server by A1RM4X 0.3
Wants=network-online.target
After=network-online.target

[Service]
User=steam
Group=steam
Environment="templdpath=$LD_LIBRARY_PATH"
Environment="LD_LIBRARY_PATH=/home/steam/:$LD_LIBRARY_PATH"
Environment="SteamAppId=2394010"
ExecStartPre=/home/steam/palworld-maintenance.sh
ExecStart=/home/steam/.steam/steam/steamapps/common/PalServer/PalServer.sh -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS > /dev/null
Restart=always
RuntimeMaxSec=4h


[Install]
WantedBy=multi-user.target
```

`palworld-proxy.service`:

```
[Unit]
Description=Palworld Proxy
BindsTo=palworld.service
After=palworld.service
PropagatesStopTo=palworld.service

[Service]
Type=notify
ExecStart=/home/steam/systemd-transparent-udp-forwarderd/systemd-transparent-udp-forwarderd 127.0.0.1:8211
Restart=on-failure

[Install]
WantedBy=default.target
```

`palworld-proxy.socket`:

```
[Socket]
ListenDatagram=0.0.0.0:27000
Transparent=true

[Install]
WantedBy=sockets.target
```

Test UDP server:

(copy-pasted from the doc mostly https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.connect )

(The server port is different and the service are somewhat similar.)

```
use std::net::UdpSocket;

fn main() -> std::io::Result<()> {
    let address = "127.0.0.1:34254";
    println!("UDP server started at {address}");
    {
        let socket = UdpSocket::bind(address)?;

        // Receives a single datagram message on the socket. If `buf` is too small to hold
        // the message, it will be cut off.
        let mut buf = [0; 10];

        loop {
            let (amt, src) = socket.recv_from(&mut buf)?;

            let s = String::from_utf8_lossy(&buf[..amt]);
            println!("received: {s:?}");

            if s.trim() == "exit" {
                break;
            }

            // Redeclare `buf` as slice of the received data and send reverse data back to origin.
            let buf = &mut buf[..amt];
            buf.reverse();
            socket.send_to(buf, &src)?;
        }
    } // the socket is closed here


    Ok(())
}
```

Test commands:

- `sudo sh -c 'echo "xx" > /dev/udp/127.0.0.1/27000'`
- `sudo sh -c 'echo "exit" > /dev/udp/127.0.0.1/27000'`
